### PR TITLE
Version 2.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ after(search, str)      // Inserts the string after the first occurence of *sear
 beforeEach(search, str) // Inserts the string before each occurence of *search*
 afterEach(search, str)  // Inserts the string after each occurence of *search*
 replace(search, str)    // Replaces each occurence of *search* with *str*
+replaceAll(search, str) // Replaces each occurence of *search* with *str*
+custom(function)        // Do what ever you want to do.
 ```
 
 ## Examples
@@ -28,78 +30,140 @@ var gulp = require('gulp'),
     rename = require('gulp-rename'),
     inject = require('gulp-inject-string');
 
-gulp.task('inject:append', function(){
-    gulp.src('src/example.html')
+function injectAppend() {
+    return gulp
+        .src('src/example.html')
         .pipe(inject.append('\n<!-- Created: ' + Date() + ' -->'))
         .pipe(rename('append.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:prepend', function(){
-    gulp.src('src/example.html')
+function injectPrepend() {
+    return gulp
+        .src('src/example.html')
         .pipe(inject.prepend('<!-- Created: ' + Date() + ' -->\n'))
         .pipe(rename('prepend.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:wrap', function(){
-    gulp.src('src/example.html')
-        .pipe(inject.wrap('<!-- Created: ' + Date() + ' -->\n', '<!-- Author: Mike Hazell -->'))
+function injectWrap() {
+    return gulp
+        .src('src/example.html')
+        .pipe(
+            inject.wrap(
+                '<!-- Created: ' + Date() + ' -->\n',
+                '<!-- Author: Mike Hazell -->'
+            )
+        )
         .pipe(rename('wrap.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:before', function(){
-    gulp.src('src/example.html')
-        .pipe(inject.before('<script', '<script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>\n'))
+function injectBefore() {
+    return gulp
+        .src('src/example.html')
+        .pipe(
+            inject.before(
+                '<script',
+                '<script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>\n'
+            )
+        )
         .pipe(rename('before.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:after', function(){
-    gulp.src('src/example.html')
-        .pipe(inject.after('</title>', '\n<link rel="stylesheet" href="test.css">\n'))
+function injectAfter() {
+    return gulp
+        .src('src/example.html')
+        .pipe(
+            inject.after(
+                '</title>',
+                '\n<link rel="stylesheet" href="test.css">\n'
+            )
+        )
         .pipe(rename('after.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:beforeEach', function(){
-    gulp.src('src/example.html')
+function injectBeforeEach() {
+    return gulp
+        .src('src/example.html')
         .pipe(inject.beforeEach('</p', ' Finis.'))
         .pipe(rename('beforeEach.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:afterEach', function(){
-    gulp.src('src/example.html')
+function injectAfterEach() {
+    return gulp
+        .src('src/example.html')
         .pipe(inject.afterEach('<p', ' class="bold"'))
         .pipe(rename('afterEach.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:replace', function(){
-    gulp.src('src/example.html')
+function injectReplace() {
+    return gulp
+        .src('src/example.html')
         .pipe(inject.replace('test.js', 'test.min.js'))
         .pipe(rename('replace.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('default', [
-    'inject:append',
-    'inject:prepend',
-    'inject:wrap',
-    'inject:before',
-    'inject:after',
-    'inject:beforeEach',
-    'inject:afterEach',
-    'inject:replace'
-]);
+function injectReplaceAll() {
+    return gulp
+        .src('src/example.html')
+        .pipe(inject.replaceAll('Lorem ipsum', 'Muspi merol'))
+        .pipe(rename('replaceAll.html'))
+        .pipe(gulp.dest('build'));
+}
 
+function injectCustom() {
+    return gulp
+        .src('src/example.html')
+        .pipe(inject.custom(function (str) {
+            return str.split('\n').reverse().join('\n')
+        }))
+        .pipe(rename('custom.html'))
+        .pipe(gulp.dest('build'));
+}
 
+exports.default = gulp.parallel(
+    injectAppend,
+    injectPrepend,
+    injectWrap,
+    injectBefore,
+    injectAfter,
+    injectBeforeEach,
+    injectAfterEach,
+    injectReplace,
+    injectReplaceAll,
+    injectCustom
+);
 ```
 
 
 ## Changes
+
+### v2.0.0 - 2019-07-12
+
+**Breaking change:**
+
+`replace` now matches the Javascript String.replace API. It can take a `String` or a `RegExp`
+as the search parameter. If given a string it will only replace the first instance of that string.
+To replace **all** instances of a string use the new method `replaceAll`.
+
+**Feature**
+
+New method `inject.custom` takes a method as it's only argument. This method will be called
+with the entire content of the file as a `String` and should return a `String`. Beyond that
+you can do what ever you want inside custom.
+
+Thanks to [Eugene Zhuchenko](https://github.com/evanre) for that one and for his patience. It took me a while to merge this.
+
+**Docs update**
+
+Updated the docs and examples to match the gulp `export` API over the older `gulp.task` api.
+
 
 ### v1.1.1 - 2018-01-09
 

--- a/examples/build/append.html
+++ b/examples/build/append.html
@@ -12,4 +12,4 @@
     </body>
 </html>
 
-<!-- Created: Thu Dec 17 2015 09:01:40 GMT+1100 (AEDT) -->
+<!-- Created: Fri Jul 12 2019 14:45:41 GMT+0200 (Central European Summer Time) -->

--- a/examples/build/custom.html
+++ b/examples/build/custom.html
@@ -1,0 +1,14 @@
+
+</html>
+    </body>
+        <script src="test.js"></script>
+
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Fugiat eveniet itaque distinctio, accusantium rem omnis.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Id sunt harum optio totam, consequatur deserunt perspiciatis placeat commodi sint dolore!</p>
+        <h1>gulp-inject-string Example</h1>
+    <body>
+    </head>
+        <title>Example</title>
+    <head>
+<html>
+<!doctype html>

--- a/examples/build/prepend.html
+++ b/examples/build/prepend.html
@@ -1,4 +1,4 @@
-<!-- Created: Thu Dec 17 2015 09:01:40 GMT+1100 (AEDT) -->
+<!-- Created: Fri Jul 12 2019 14:45:41 GMT+0200 (Central European Summer Time) -->
 <!doctype html>
 <html>
     <head>

--- a/examples/build/replaceAll.html
+++ b/examples/build/replaceAll.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Example</title>
+    </head>
+    <body>
+        <h1>gulp-inject-string Example</h1>
+        <p>Muspi merol dolor sit amet, consectetur adipisicing elit. Id sunt harum optio totam, consequatur deserunt perspiciatis placeat commodi sint dolore!</p>
+        <p>Muspi merol dolor sit amet, consectetur adipisicing elit. Fugiat eveniet itaque distinctio, accusantium rem omnis.</p>
+
+        <script src="test.js"></script>
+    </body>
+</html>

--- a/examples/build/wrap.html
+++ b/examples/build/wrap.html
@@ -1,4 +1,4 @@
-<!-- Created: Thu Dec 17 2015 09:01:40 GMT+1100 (AEDT) -->
+<!-- Created: Fri Jul 12 2019 14:45:41 GMT+0200 (Central European Summer Time) -->
 <!doctype html>
 <html>
     <head>

--- a/examples/gulpfile.js
+++ b/examples/gulpfile.js
@@ -2,22 +2,25 @@ var gulp = require('gulp'),
     rename = require('gulp-rename'),
     inject = require('../');
 
-gulp.task('inject:append', function() {
-    gulp.src('src/example.html')
+function injectAppend() {
+    return gulp
+        .src('src/example.html')
         .pipe(inject.append('\n<!-- Created: ' + Date() + ' -->'))
         .pipe(rename('append.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:prepend', function() {
-    gulp.src('src/example.html')
+function injectPrepend() {
+    return gulp
+        .src('src/example.html')
         .pipe(inject.prepend('<!-- Created: ' + Date() + ' -->\n'))
         .pipe(rename('prepend.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:wrap', function() {
-    gulp.src('src/example.html')
+function injectWrap() {
+    return gulp
+        .src('src/example.html')
         .pipe(
             inject.wrap(
                 '<!-- Created: ' + Date() + ' -->\n',
@@ -26,10 +29,11 @@ gulp.task('inject:wrap', function() {
         )
         .pipe(rename('wrap.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:before', function() {
-    gulp.src('src/example.html')
+function injectBefore() {
+    return gulp
+        .src('src/example.html')
         .pipe(
             inject.before(
                 '<script',
@@ -38,10 +42,11 @@ gulp.task('inject:before', function() {
         )
         .pipe(rename('before.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:after', function() {
-    gulp.src('src/example.html')
+function injectAfter() {
+    return gulp
+        .src('src/example.html')
         .pipe(
             inject.after(
                 '</title>',
@@ -50,36 +55,64 @@ gulp.task('inject:after', function() {
         )
         .pipe(rename('after.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:beforeEach', function() {
-    gulp.src('src/example.html')
+function injectBeforeEach() {
+    return gulp
+        .src('src/example.html')
         .pipe(inject.beforeEach('</p', ' Finis.'))
         .pipe(rename('beforeEach.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:afterEach', function() {
-    gulp.src('src/example.html')
+function injectAfterEach() {
+    return gulp
+        .src('src/example.html')
         .pipe(inject.afterEach('<p', ' class="bold"'))
         .pipe(rename('afterEach.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('inject:replace', function() {
-    gulp.src('src/example.html')
+function injectReplace() {
+    return gulp
+        .src('src/example.html')
         .pipe(inject.replace('test.js', 'test.min.js'))
         .pipe(rename('replace.html'))
         .pipe(gulp.dest('build'));
-});
+}
 
-gulp.task('default', [
-    'inject:append',
-    'inject:prepend',
-    'inject:wrap',
-    'inject:before',
-    'inject:after',
-    'inject:beforeEach',
-    'inject:afterEach',
-    'inject:replace',
-]);
+function injectReplaceAll() {
+    return gulp
+        .src('src/example.html')
+        .pipe(inject.replaceAll('Lorem ipsum', 'Muspi merol'))
+        .pipe(rename('replaceAll.html'))
+        .pipe(gulp.dest('build'));
+}
+
+function injectCustom() {
+    return gulp
+        .src('src/example.html')
+        .pipe(
+            inject.custom(function(str) {
+                return str
+                    .split('\n')
+                    .reverse()
+                    .join('\n');
+            })
+        )
+        .pipe(rename('custom.html'))
+        .pipe(gulp.dest('build'));
+}
+
+exports.default = gulp.parallel(
+    injectAppend,
+    injectPrepend,
+    injectWrap,
+    injectBefore,
+    injectAfter,
+    injectBeforeEach,
+    injectAfterEach,
+    injectReplace,
+    injectReplaceAll,
+    injectCustom
+);

--- a/index.js
+++ b/index.js
@@ -78,7 +78,19 @@ module.exports = {
     },
     replace: function(search, str) {
         return stream(function(fileContents) {
-            return fileContents.replace(new RegExp(search, 'g'), str);
+            if (search instanceof RegExp) {
+                return fileContents.replace(search, str);
+            }
+
+            // This will be slower than the regex version but avoids regex injection issues.
+            if (typeof search === 'string') {
+                while (fileContents.includes(search)) {
+                    fileContents = fileContents.replace(search, str);
+                }
+                return fileContents;
+            }
+
+            return fileContents;
         });
     },
 };

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var es = require('event-stream'),
 var stream = function(injectMethod) {
     return es.map(function(file, cb) {
         try {
-            file.contents = new Buffer(injectMethod(String(file.contents)));
+            file.contents = Buffer.from(injectMethod(String(file.contents)));
         } catch (err) {
             return cb(new PluginError('gulp-inject-string', err));
         }
@@ -78,18 +78,22 @@ module.exports = {
     },
     replace: function(search, str) {
         return stream(function(fileContents) {
+            return fileContents.replace(search, str);
+        });
+    },
+    replaceAll: function(search, str) {
+        return stream(function(fileContents) {
             if (search instanceof RegExp) {
-                return fileContents.replace(search, str);
+                throw new Error(
+                    'replaceAll can only take a string. Use `replace` with a regex and set the global flag `g` to replace all matches.'
+                );
             }
-
-            // This will be slower than the regex version but avoids regex injection issues.
             if (typeof search === 'string') {
                 while (fileContents.includes(search)) {
                     fileContents = fileContents.replace(search, str);
                 }
                 return fileContents;
             }
-
             return fileContents;
         });
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-inject-string",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Inject snippets in build",
   "main": "index.js",
   "scripts": {

--- a/tests/expected/after.html
+++ b/tests/expected/after.html
@@ -9,5 +9,9 @@
         <span>First occurence of span</span>
         <span>Second occurence of span</span>
         <!-- TEST COMMENT -->
+        <script>
+            /* a block comment */
+            var someVariable = process.env.SUPER_SECRET_KEY;
+        </script>
     </body><h1>After test</h1>
 </html>

--- a/tests/expected/afterEach2.html
+++ b/tests/expected/afterEach2.html
@@ -9,6 +9,10 @@
         <span>First occurence of span</span>
         <span>Second occurence of span</span>
         <!-- TEST COMMENT -->
+        <script>
+            /* a block comment */
+            var someVariable = process.env.SUPER_SECRET_KEY;
+        </script>
     </body>
 </html>
 <!-- this is a poor example but should still work -->

--- a/tests/expected/before.html
+++ b/tests/expected/before.html
@@ -9,5 +9,9 @@
         <span>First occurence of span</span>
         <span>Second occurence of span</span>
         <!-- TEST COMMENT -->
+        <script>
+            /* a block comment */
+            var someVariable = process.env.SUPER_SECRET_KEY;
+        </script>
     <h1>Before test</h1></body>
 </html>

--- a/tests/expected/beforeEach.html
+++ b/tests/expected/beforeEach.html
@@ -9,5 +9,9 @@
         <h1>Before test</h1><span>First occurence of span</span>
         <h1>Before test</h1><span>Second occurence of span</span>
         <!-- TEST COMMENT -->
+        <script>
+            /* a block comment */
+            var someVariable = process.env.SUPER_SECRET_KEY;
+        </script>
     </body>
 </html>

--- a/tests/expected/beforeEach2.html
+++ b/tests/expected/beforeEach2.html
@@ -10,5 +10,9 @@
         <span>First occurence of span</span>
         <span>Second occurence of span</span>
         <!-- TEST COMMENT -->
+        <script>
+            /* a block comment */
+            var someVariable = process.env.SUPER_SECRET_KEY;
+        </script>
     </body>
 </html>

--- a/tests/expected/replace.html
+++ b/tests/expected/replace.html
@@ -9,5 +9,9 @@
         <span>First occurence of span</span>
         <span>Second occurence of span</span>
         <!-- IT WORKS -->
+        <script>
+            /* a block comment */
+            var someVariable = process.env.SUPER_SECRET_KEY;
+        </script>
     </body>
 </html>

--- a/tests/expected/replace2.html
+++ b/tests/expected/replace2.html
@@ -9,5 +9,9 @@
         <span>First occurence of span</span>
         <span>Second occurence of span</span>
         <!-- TEST COMMENT -->
+        <script>
+            /* a block comment */
+            var someVariable = process.env.SUPER_SECRET_KEY;
+        </script>
     </body>
 </html>

--- a/tests/expected/replace2.html
+++ b/tests/expected/replace2.html
@@ -1,17 +1,17 @@
 <!doctype html>
 <html>
     <head>
-        <title>New title</title>
+        <title>Test file</title>
     </head>
     <body>
-        <h1>New title</h1>
+        <h1>Test file</h1>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corrupti, consequuntur.</p>
         <span>First occurence of span</span>
         <span>Second occurence of span</span>
         <!-- TEST COMMENT -->
         <script>
             /* a block comment */
-            var someVariable = process.env.SUPER_SECRET_KEY;
+            var someVariable = "12345";
         </script>
     </body>
 </html>

--- a/tests/expected/replace3.html
+++ b/tests/expected/replace3.html
@@ -10,8 +10,8 @@
         <span>Second occurence of span</span>
         <!-- TEST COMMENT -->
         <script>
-            /* a block comment */
-            var someVariable = "12345";
+            // A regular comment
+            var someVariable = process.env.SUPER_SECRET_KEY;
         </script>
     </body>
 </html>

--- a/tests/expected/replace3.html
+++ b/tests/expected/replace3.html
@@ -6,12 +6,12 @@
     <body>
         <h1>Test file</h1>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corrupti, consequuntur.</p>
-        <span>First occurence of span</span><h1>After test</h1>
-        <span>Second occurence of span</span><h1>After test</h1>
+        <span>First occurence of span</span>
+        <span>Second occurence of span</span>
         <!-- TEST COMMENT -->
         <script>
             /* a block comment */
-            var someVariable = process.env.SUPER_SECRET_KEY;
+            var someVariable = "12345";
         </script>
     </body>
 </html>

--- a/tests/expected/replace4.html
+++ b/tests/expected/replace4.html
@@ -6,11 +6,11 @@
     <body>
         <h1>Test file</h1>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corrupti, consequuntur.</p>
-        <span>First occurence of span</span><h1>After test</h1>
-        <span>Second occurence of span</span><h1>After test</h1>
+        <span>First occurence of span</span>
+        <span>Second occurence of span</span>
         <!-- TEST COMMENT -->
         <script>
-            /* a block comment */
+            // A regular comment
             var someVariable = process.env.SUPER_SECRET_KEY;
         </script>
     </body>

--- a/tests/expected/replaceAll.html
+++ b/tests/expected/replaceAll.html
@@ -1,16 +1,16 @@
 <!doctype html>
 <html>
     <head>
-        <title>Test file</title>
+        <title>New title</title>
     </head>
     <body>
-        <h1>Test file</h1>
+        <h1>New title</h1>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corrupti, consequuntur.</p>
         <span>First occurence of span</span>
         <span>Second occurence of span</span>
         <!-- TEST COMMENT -->
         <script>
-            // A regular comment
+            /* a block comment */
             var someVariable = process.env.SUPER_SECRET_KEY;
         </script>
     </body>

--- a/tests/fixtures/index.html
+++ b/tests/fixtures/index.html
@@ -9,5 +9,9 @@
         <span>First occurence of span</span>
         <span>Second occurence of span</span>
         <!-- TEST COMMENT -->
+        <script>
+            /* a block comment */
+            var someVariable = process.env.SUPER_SECRET_KEY;
+        </script>
     </body>
 </html>

--- a/tests/test.js
+++ b/tests/test.js
@@ -430,7 +430,9 @@ describe('gulp-inject-string', function() {
 
             stream.once('error', function(error) {
                 expect(error.plugin).to.equal('gulp-inject-string');
-                expect(error.message).to.contain('replaceAll can only take a string');
+                expect(error.message).to.contain(
+                    'replaceAll can only take a string'
+                );
                 done();
             });
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -46,7 +46,7 @@ describe('gulp-inject-string', function() {
                 base: 'test/fixtures',
                 cwd: 'test/',
                 path: 'test/fixtures/index.html',
-                contents: new Buffer(fixtureFile),
+                contents: Buffer.from(fixtureFile),
             });
         });
 
@@ -71,7 +71,7 @@ describe('gulp-inject-string', function() {
                 base: 'test/fixtures',
                 cwd: 'test/',
                 path: 'test/fixtures/index.html',
-                contents: new Buffer(fixtureFile),
+                contents: Buffer.from(fixtureFile),
             });
         });
 
@@ -96,7 +96,7 @@ describe('gulp-inject-string', function() {
                 base: 'test/fixtures',
                 cwd: 'test/',
                 path: 'test/fixtures/index.html',
-                contents: new Buffer(fixtureFile),
+                contents: Buffer.from(fixtureFile),
             });
         });
 
@@ -121,7 +121,7 @@ describe('gulp-inject-string', function() {
                 base: 'test/fixtures',
                 cwd: 'test',
                 path: 'test/fixtures/index.html',
-                contents: new Buffer(fixtureFile),
+                contents: Buffer.from(fixtureFile),
             });
         });
 
@@ -160,7 +160,7 @@ describe('gulp-inject-string', function() {
                 base: 'test/fixtures',
                 cwd: 'test',
                 path: 'test/fixtures/index.html',
-                contents: new Buffer(fixtureFile),
+                contents: Buffer.from(fixtureFile),
             });
         });
 
@@ -199,7 +199,7 @@ describe('gulp-inject-string', function() {
                 base: 'test/fixtures',
                 cwd: 'test',
                 path: 'test/fixtures/index.html',
-                contents: new Buffer(fixtureFile),
+                contents: Buffer.from(fixtureFile),
             });
         });
 
@@ -258,7 +258,7 @@ describe('gulp-inject-string', function() {
                 base: 'test/fixtures',
                 cwd: 'test',
                 path: 'test/fixtures/index.html',
-                contents: new Buffer(fixtureFile),
+                contents: Buffer.from(fixtureFile),
             });
         });
 
@@ -314,7 +314,7 @@ describe('gulp-inject-string', function() {
                 base: 'test/fixtures',
                 cwd: 'test',
                 path: 'test/fixtures/index.html',
-                contents: new Buffer(fixtureFile),
+                contents: Buffer.from(fixtureFile),
             });
         });
 
@@ -335,27 +335,13 @@ describe('gulp-inject-string', function() {
             stream.write(fakeFile);
         });
 
-        it('should replace every instance of the search string with the given string', function(done) {
-            var stream = inject.replace('Test file', 'New title');
-            var expectedFile = fs.readFileSync(
-                path.join(__dirname, './expected/replace2.html')
-            );
-
-            stream.once('data', function(newFile) {
-                expect(String(newFile.contents)).to.equal(String(expectedFile));
-                done();
-            });
-
-            stream.write(fakeFile);
-        });
-
         it('should not care about being inside a script', function(done) {
             var stream = inject.replace(
                 'process.env.SUPER_SECRET_KEY',
                 '"12345"'
             );
             var expectedFile = fs.readFileSync(
-                path.join(__dirname, './expected/replace3.html')
+                path.join(__dirname, './expected/replace2.html')
             );
 
             stream.once('data', function(newFile) {
@@ -372,7 +358,7 @@ describe('gulp-inject-string', function() {
                 '// A regular comment'
             );
             var expectedFile = fs.readFileSync(
-                path.join(__dirname, './expected/replace4.html')
+                path.join(__dirname, './expected/replace3.html')
             );
 
             stream.once('data', function(newFile) {
@@ -389,7 +375,7 @@ describe('gulp-inject-string', function() {
                 '// A regular comment'
             );
             var expectedFile = fs.readFileSync(
-                path.join(__dirname, './expected/replace4.html')
+                path.join(__dirname, './expected/replace3.html')
             );
 
             stream.once('data', function(newFile) {
@@ -406,6 +392,45 @@ describe('gulp-inject-string', function() {
 
             stream.once('data', function(newFile) {
                 expect(String(newFile.contents)).to.equal(expectedFile);
+                done();
+            });
+
+            stream.write(fakeFile);
+        });
+    });
+
+    describe('replaceAll', function() {
+        var fakeFile;
+
+        beforeEach(function() {
+            fakeFile = new Vinyl({
+                base: 'test/fixtures',
+                cwd: 'test',
+                path: 'test/fixtures/index.html',
+                contents: Buffer.from(fixtureFile),
+            });
+        });
+
+        it('should replace every instance of the search string with the given string', function(done) {
+            var stream = inject.replaceAll('Test file', 'New title');
+            var expectedFile = fs.readFileSync(
+                path.join(__dirname, './expected/replaceAll.html')
+            );
+
+            stream.once('data', function(newFile) {
+                expect(String(newFile.contents)).to.equal(String(expectedFile));
+                done();
+            });
+
+            stream.write(fakeFile);
+        });
+
+        it('should throw with an error if you pass a regex as the search param', function(done) {
+            var stream = inject.replaceAll(/Text file/, 'New title');
+
+            stream.once('error', function(error) {
+                expect(error.plugin).to.equal('gulp-inject-string');
+                expect(error.message).to.contain('replaceAll can only take a string');
                 done();
             });
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -476,6 +476,21 @@ describe('gulp-inject-string', function() {
 
             stream.write(fakeFile);
         });
+
+        it('can replace the entire contents of a file', function(done) {
+            var stream = inject.custom(function(str) {
+                return 'Something completely different';
+            });
+
+            stream.once('data', function(newFile) {
+                expect(String(newFile.contents)).to.equal(
+                    'Something completely different'
+                );
+                done();
+            });
+
+            stream.write(fakeFile);
+        });
     });
 
     describe('_stream', function() {

--- a/tests/test.js
+++ b/tests/test.js
@@ -349,6 +349,57 @@ describe('gulp-inject-string', function() {
             stream.write(fakeFile);
         });
 
+        it('should not care about being inside a script', function(done) {
+            var stream = inject.replace(
+                'process.env.SUPER_SECRET_KEY',
+                '"12345"'
+            );
+            var expectedFile = fs.readFileSync(
+                path.join(__dirname, './expected/replace3.html')
+            );
+
+            stream.once('data', function(newFile) {
+                expect(String(newFile.contents)).to.equal(String(expectedFile));
+                done();
+            });
+
+            stream.write(fakeFile);
+        });
+
+        it('should replace a string containing regex special chars', function(done) {
+            var stream = inject.replace(
+                '/* a block comment */',
+                '// A regular comment'
+            );
+            var expectedFile = fs.readFileSync(
+                path.join(__dirname, './expected/replace4.html')
+            );
+
+            stream.once('data', function(newFile) {
+                expect(String(newFile.contents)).to.equal(String(expectedFile));
+                done();
+            });
+
+            stream.write(fakeFile);
+        });
+
+        it('should accept a regular expression as an argument', function(done) {
+            var stream = inject.replace(
+                /\/\* a block comment \*\//gi,
+                '// A regular comment'
+            );
+            var expectedFile = fs.readFileSync(
+                path.join(__dirname, './expected/replace4.html')
+            );
+
+            stream.once('data', function(newFile) {
+                expect(String(newFile.contents)).to.equal(String(expectedFile));
+                done();
+            });
+
+            stream.write(fakeFile);
+        });
+
         it('should do nothing if the search string is not found', function(done) {
             var stream = inject.replace('IAMNOTTHERE', 'NEITHERAMI');
             var expectedFile = String(fixtureFile);

--- a/tests/test.js
+++ b/tests/test.js
@@ -36,6 +36,9 @@ describe('gulp-inject-string', function() {
         it('should define a replace method', function() {
             expect(inject.replace).to.be.a('function');
         });
+        it('should define a replaceAll method', function() {
+            expect(inject.replaceAll).to.be.a('function');
+        });
     });
 
     describe('append', function() {


### PR DESCRIPTION
This PR will be released as v2.0.0

**Breaking change:**

`replace` now matches the Javascript `String.replace` API. It can take a `String` or a `RegExp`
as the search parameter. If given a string it will only replace the first instance of that string.
To replace **all** instances of a string use the new method `replaceAll`.

**Feature**

New method `inject.custom` takes a method as it's only argument. This method will be called
with the entire content of the file as a `String` and should return a `String`. Beyond that
you can do what ever you want inside custom.

Thanks to [Eugene Zhuchenko](https://github.com/evanre) for that one and for his patience. It took me a while to merge this.

resolves #8 and #5
